### PR TITLE
Fix: vercel for backend

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
   "builds": [{ "src": "api/index.ts", "use": "@vercel/node" }],
-  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }],
+  "outputDirectory": "public"
 }


### PR DESCRIPTION
This pull request updates the `vercel.json` configuration file to include an `outputDirectory` property, which specifies the directory where static files will be served.

* Configuration update:
  * [`backend/vercel.json`](diffhunk://#diff-73df426298816a3ef91dac63f74e9865b32d9c4fbace61f4cae920f8d17c412cL4-R5): Added the `outputDirectory` property with the value `"public"` to configure the directory for serving static files.