### PR TITLE
Fix: Vercel

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
   "builds": [{ "src": "api/index.ts", "use": "@vercel/node" }],
-  "rewrites": [{ "source": "/(.*)", "destination": "/api" }]
+  "rewrites": [{ "source": "/(.*)", "destination": "/api" }],
+  "public": false
 }


### PR DESCRIPTION
This pull request includes a small change to the `backend/vercel.json` configuration file. The change adds a `public` property set to `false`, likely to restrict public access to the deployment.