### PR TITLE
Update passport.ts

### DIFF
--- a/backend/api/config/passport.ts
+++ b/backend/api/config/passport.ts
@@ -5,7 +5,6 @@ import User, { IUser } from '../models/user';
 // Validate environment variables
 if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
   console.error('Missing Google OAuth credentials in environment variables');
-  process.exit(1);
 }
 
 passport.use(


### PR DESCRIPTION
This pull request removes the termination of the process when Google OAuth credentials are missing in the environment variables. Instead, it allows the application to continue running, potentially enabling other functionality to remain operational.

Key change:

* [`backend/api/config/passport.ts`](diffhunk://#diff-91b2dd69e1fb9c3c4b5c871e3787db4ea6d25185400aafd67a00cdcfd1fd1be0L8): Removed the `process.exit(1)` call when Google OAuth credentials are not found in the environment variables.