### PR TITLE
Update vercel.json

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -3,7 +3,7 @@
   "builds": [
     { "src": "api/index.ts", "use": "@vercel/node" }
   ],
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/api" }
+  "routes": [
+    { "src": "/(.*)", "dest": "/api/index.ts" }
   ]
 }


### PR DESCRIPTION
This pull request updates the `vercel.json` configuration file to align with the latest Vercel routing conventions.

Configuration updates:

* Replaced the deprecated `rewrites` property with the `routes` property to define routing rules. The new configuration specifies that requests matching the pattern `/(.*)` are routed to `/api/index.ts`. (`backend/vercel.json`, [backend/vercel.jsonL6-R7](diffhunk://#diff-73df426298816a3ef91dac63f74e9865b32d9c4fbace61f4cae920f8d17c412cL6-R7))