### PR TITLE
Remove: process.exit(1); for vercel

### DIFF
--- a/backend/api/database/db.ts
+++ b/backend/api/database/db.ts
@@ -25,8 +25,7 @@ const connectDB = async (): Promise<typeof mongoose> => {
     console.error(
       `Error connecting to MongoDB: ${error instanceof Error ? error.message : String(error)}`,
     );
-    process.exit(1);
+    throw error;
   }
 };
-
 export default connectDB;

--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -36,11 +36,15 @@ app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   res.status(500).json({ error: 'Server error' });
 });
 
-connectDB();
-
-app.listen(port, () => {
-  console.log(`Server running at http://localhost:${port}`);
-});
+connectDB()
+  .then(() => {
+    app.listen(port, () => {
+      console.log(`Server running at http://localhost:${port}`);
+    });
+  })
+  .catch((err) => {
+    console.error('Failed to start server:', err);
+  });
 
 export default app;
 module.exports = app;


### PR DESCRIPTION
This pull request improves error handling in the server startup process by replacing a forced process exit with error propagation and adding proper handling for database connection failures. 

### Error Handling Improvements:

* [`backend/api/database/db.ts`](diffhunk://#diff-4543d94c7f7e7c2ac1f996c45f15869f27cb7fe187a7582dcd67afcf9562e683L28-L31): Updated the `connectDB` function to throw an error instead of exiting the process with `process.exit(1)`. This allows the caller to handle the error gracefully.

* [`backend/api/index.ts`](diffhunk://#diff-447d7e955dffa2b6f442ae8c60c28b144ee7f7099defdd1abff19242b41b097fL39-R47): Modified the server initialization to handle database connection errors. The `connectDB` function is now called with a `.then` and `.catch` block to ensure the server only starts if the database connection is successful. Errors during the connection process are logged, and the server startup is aborted.