### PR TITLE
Update tsconfig.build.json

### DIFF
--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -2,7 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmitOnError": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
   "exclude": ["api/__test__/**/*", "**/*.test.ts", "node_modules"]
 }


### PR DESCRIPTION
This pull request updates the TypeScript build configuration to include additional type definitions for Node.js. 

* [`backend/tsconfig.build.json`](diffhunk://#diff-8856359f85d2cc53f7c79b81d0b74eea4a87b0c00c71d2b75a62dd3a638616ddL5-R6): Added `"types": ["node"]` to the `compilerOptions` to ensure Node.js types are available during the build process.