### PR TITLE
Fix: uppdate passport in package.json

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,7 +21,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "mongoose": "^8.15.1",
-        "passport": "^0.4.1",
+        "passport": ">=0.6.0",
         "passport-google-oauth20": "^2.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
@@ -8365,16 +8365,21 @@
       }
     },
     "node_modules/passport": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
-      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.6.0.tgz",
+      "integrity": "sha512-0fe+p3ZnrWRW74fe8+SvCyf4a3Pb2/h7gFkQ8yTJpAO50gDzlfjZUZTO1k5Eg9kUct22OxHLqDZoKUWRHOh9ug==",
       "license": "MIT",
       "dependencies": {
         "passport-strategy": "1.x.x",
-        "pause": "0.0.1"
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-google-oauth20": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -52,7 +52,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "mongoose": "^8.15.1",
-    "passport": "^0.4.1",
+    "passport": ">=0.6.0",
     "passport-google-oauth20": "^2.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"


### PR DESCRIPTION
This pull request updates the `passport` dependency in the backend to a newer version and adjusts related metadata in `package.json` and `package-lock.json`. These changes ensure compatibility with the latest features and security updates.

Dependency updates:

* Updated the `passport` dependency version from `^0.4.1` to `>=0.6.0` in `backend/package.json` and `backend/package-lock.json`. This change ensures that the project uses a more recent version of `passport` with improved features and security fixes. [[1]](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L55-R55) [[2]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cL24-R24)

Metadata adjustments:

* Updated the `passport` metadata in `backend/package-lock.json` to reflect the new version (`0.6.0`), including its `resolved` URL, `integrity` hash, and dependencies. Added a `funding` field to indicate GitHub sponsorship for the library's maintainer.