### PR TITLE
Feat: titleupdate create

### DIFF
--- a/frontend/hajkmat-frontend/index.html
+++ b/frontend/hajkmat-frontend/index.html
@@ -1,13 +1,15 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Hajkmat - Matplaneraren</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/frontend/hajkmat-frontend/src/App.tsx
+++ b/frontend/hajkmat-frontend/src/App.tsx
@@ -1,11 +1,13 @@
 import { BrowserRouter as Router } from 'react-router-dom';
 import Header from './components/Header/Header';
 import Footer from './components/Footer/Footer';
+import TitleUpdater from './components/TitleUpdater';
 import './App.css';
 
 function App() {
   return (
     <Router>
+      <TitleUpdater />
       <div className="flex flex-col min-h-screen">
         <Header />
         <main className="flex-grow">{/* Your page content goes here */}</main>

--- a/frontend/hajkmat-frontend/src/components/Main/Home/Home.tsx
+++ b/frontend/hajkmat-frontend/src/components/Main/Home/Home.tsx
@@ -1,0 +1,14 @@
+import { useDocumentTitle } from '../../../hooks/useDocumentTitle';
+
+const Home = () => {
+  useDocumentTitle('Matplaneraren');
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Välkommen till Hajkmat</h1>
+      {/* Rest of your home page content */}
+    </div>
+  );
+};
+
+export default Home;

--- a/frontend/hajkmat-frontend/src/components/TitleUpdater.ts
+++ b/frontend/hajkmat-frontend/src/components/TitleUpdater.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const TitleUpdater = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const pageTitles: Record<string, string> = {
+      '/': 'Matplaneraren',
+      '/profile': 'Profil',
+      '/lists': 'Matlistor',
+      '/about': 'Om Hajkmat',
+      // Add more routes as needed
+    };
+
+    const pageTitle = pageTitles[location.pathname] || 'Matplaneraren';
+    document.title = `Hajkmat | ${pageTitle} `;
+  }, [location.pathname]);
+
+  return null; // This component doesn't render anything
+};
+
+export default TitleUpdater;

--- a/frontend/hajkmat-frontend/src/hooks/useDocumentTitle.ts
+++ b/frontend/hajkmat-frontend/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+
+/**
+ * A custom hook that updates the document title
+ * @param title - The page-specific title
+ * @param siteName - The site name to append (defaults to "Hajkmat")
+ */
+export function useDocumentTitle(title: string, siteName = 'Hajkmat') {
+  useEffect(() => {
+    // Save the original title to restore when component unmounts
+    const originalTitle = document.title;
+
+    // Update the title with the new value
+    document.title = title ? `${title} | ${siteName}` : `${siteName} - Matplaneraren`;
+
+    // Cleanup function to reset the title when component unmounts
+    return () => {
+      document.title = originalTitle;
+    };
+  }, [title, siteName]);
+}


### PR DESCRIPTION
This pull request introduces dynamic document title management for the Hajkmat frontend application. Key changes include updating the default page title, adding a reusable `TitleUpdater` component for route-based title updates, and implementing a custom hook for page-specific title settings.

### Document Title Management Enhancements:

* **Default Page Title Update**:
  - Changed the default title in `index.html` to "Hajkmat - Matplaneraren" for better branding. (`frontend/hajkmat-frontend/index.html`)

* **Route-Based Title Updates**:
  - Added a new `TitleUpdater` component that dynamically updates the document title based on the current route using a predefined mapping. (`frontend/hajkmat-frontend/src/components/TitleUpdater.ts`)
  - Integrated `TitleUpdater` into the main application layout in `App.tsx`. (`frontend/hajkmat-frontend/src/App.tsx`)

* **Custom Hook for Page-Specific Titles**:
  - Created a `useDocumentTitle` hook to allow individual components to set custom document titles while retaining the site branding. (`frontend/hajkmat-frontend/src/hooks/useDocumentTitle.ts`)
  - Applied the `useDocumentTitle` hook in the `Home` component to set a specific title for the homepage. (`frontend/hajkmat-frontend/src/components/Main/Home/Home.tsx`)