### PR TITLE
Fix: passoprt callback

### DIFF
--- a/backend/api/config/passport.ts
+++ b/backend/api/config/passport.ts
@@ -22,7 +22,10 @@ passport.use(
     {
       clientID: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-      callbackURL: 'http://localhost:5173/api/auth/google/callback',
+      callbackURL:
+        process.env.NODE_ENV === 'production'
+          ? 'https://u09-business-project-hajkmat.onrender.com/api/auth/google/callback' // Backend URL
+          : 'http://localhost:3000/api/auth/google/callback',
       scope: ['profile', 'email'],
     },
     async (accessToken: string, refreshToken: string, profile: Profile, done: VerifyCallback) => {


### PR DESCRIPTION
This pull request updates the Google OAuth callback URL configuration in the `passport.use` method to dynamically switch between production and development environments.

Authentication configuration updates:

* [`backend/api/config/passport.ts`](diffhunk://#diff-91b2dd69e1fb9c3c4b5c871e3787db4ea6d25185400aafd67a00cdcfd1fd1be0L25-R28): Modified the `callbackURL` to use the production backend URL (`https://u09-business-project-hajkmat.onrender.com/api/auth/google/callback`) when `NODE_ENV` is set to 'production', and the local development URL (`http://localhost:3000/api/auth/google/callback`) otherwise.