### PR TITLE
Feat: delete account

### DIFF
--- a/backend/api/routes/auth.ts
+++ b/backend/api/routes/auth.ts
@@ -4,6 +4,9 @@ import passport from 'passport';
 import cors from 'cors';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 import env from '../config/env';
+import { authenticate } from '../middleware/auth';
+import RecipeList from '../models/recipeList';
+import User from '../models/user';
 
 interface UserPayload extends JwtPayload {
   id: string;
@@ -118,6 +121,26 @@ router.post('/logout', (req: Request, res: Response) => {
     }
     res.status(200).json({ success: true });
   });
+});
+
+router.delete('/delete-account', authenticate, async (req: Request, res: Response) => {
+  try {
+    const userId = (req.user as any).id;
+
+    const deletedUser = await User.findByIdAndDelete(userId);
+
+    if (!deletedUser) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    await RecipeList.deleteMany({ user: userId });
+
+    res.status(200).json({ message: 'Account deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting account:', error);
+    res.status(500).json({ error: 'Failed to delete account' });
+  }
 });
 
 export default router;


### PR DESCRIPTION
This pull request adds functionality to delete a user account and its associated data in the `backend/api/routes/auth.ts` file. It introduces a new route, leverages middleware for authentication, and integrates database operations to ensure proper cleanup.

### New functionality for account deletion:

* **Added imports for required models and middleware**: Included `authenticate` middleware, `RecipeList` model, and `User` model to support the new account deletion feature. (`[backend/api/routes/auth.tsR7-R9](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8R7-R9)`)
* **Implemented `/delete-account` route**: Created a new `DELETE` endpoint that uses the `authenticate` middleware to verify the user. It deletes the user from the database and removes all associated recipe lists, ensuring data cleanup. Handles errors gracefully with appropriate status codes and messages. (`[backend/api/routes/auth.tsR126-R145](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8R126-R145)`)