### PR TITLE
trying to tell it is express

### DIFF
--- a/backend/api/routes/auth.ts
+++ b/backend/api/routes/auth.ts
@@ -1,4 +1,4 @@
-import { Router, Request, Response } from 'express';
+import express, { Request, Response } from 'express';
 import { login, register } from '../controllers/authControllers';
 import passport from 'passport';
 import cors from 'cors';
@@ -22,7 +22,7 @@ const corsOptions = {
     process.env.NODE_ENV === 'production' ? 'https://hajkmat.netlify.app' : 'http://localhost:5173',
   credentials: true,
 };
-const router = Router();
+const router = express.Router();
 router.get('/test', (req, res) => {
   console.log('Auth test route accessed');
   res.json({ message: 'Auth test route works' });

--- a/backend/api/routes/recipeLists.ts
+++ b/backend/api/routes/recipeLists.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import express from 'express';
 import {
   createRecipeList,
   getRecipeLists,
@@ -7,7 +7,7 @@ import {
 } from '../controllers/recipeListControllers';
 import { authenticate } from '../middleware/auth';
 
-const router = Router();
+const router = express.Router();
 
 // Create a new recipe list
 router.post('/', authenticate, createRecipeList);


### PR DESCRIPTION
This pull request refactors imports and router initialization in multiple route files to simplify and standardize the code. The changes replace `Router` imports with `express.Router()` and update the import statements to directly import `express`.

### Refactoring imports:

* [`backend/api/routes/auth.ts`](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8L1-R1): Replaced the `Router` import with `express.Router()` and updated the import statement to directly import `express`.
* [`backend/api/routes/recipeLists.ts`](diffhunk://#diff-074b1619ae4c7f5d06d353f15a40988233bcd81d85a52b785aaab375cd1565bcL1-R1): Updated the import statement to directly import `express` instead of `Router`.

### Router initialization standardization:

* [`backend/api/routes/auth.ts`](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8L25-R25): Updated the router initialization to use `express.Router()` instead of `Router`.
* [`backend/api/routes/recipeLists.ts`](diffhunk://#diff-074b1619ae4c7f5d06d353f15a40988233bcd81d85a52b785aaab375cd1565bcL10-R10): Changed the router initialization to use `express.Router()` for consistency.