### PR TITLE
Fix: so id is _id working with mongodb

### DIFF
--- a/backend/api/controllers/authControllers.ts
+++ b/backend/api/controllers/authControllers.ts
@@ -50,7 +50,9 @@ export const logout = (req: Request, res: Response) => {
 
 export const deleteAccount = async (req: Request, res: Response): Promise<void> => {
   try {
-    const userId = (req.user as any).id;
+    const userId = (req.user as any)._id || (req.user as any).id;
+    console.log('User object from request:', req.user);
+    console.log('Attempting to delete user with ID:', userId);
 
     const deletedUser = await User.findByIdAndDelete(userId);
 

--- a/backend/api/controllers/recipeListControllers.ts
+++ b/backend/api/controllers/recipeListControllers.ts
@@ -10,7 +10,7 @@ export const createRecipeList = async (req: Request, res: Response): Promise<voi
     return;
   }
 
-  const userId = (req.user as any).id;
+  const userId = (req.user as any)._id;
 
   try {
     const newList = new RecipeList({ name, user: userId });
@@ -29,7 +29,7 @@ export const getRecipeLists = async (req: Request, res: Response): Promise<void>
     return;
   }
 
-  const userId = (req.user as any).id;
+  const userId = (req.user as any)._id;
 
   try {
     const lists = await RecipeList.find({ user: userId });
@@ -50,7 +50,7 @@ export const updateRecipeList = async (req: Request, res: Response): Promise<voi
     return;
   }
 
-  const userId = (req.user as any).id;
+  const userId = (req.user as any)._id;
 
   try {
     // Find the recipe list and ensure it belongs to the current user
@@ -83,7 +83,7 @@ export const deleteRecipeList = async (req: Request, res: Response): Promise<voi
     return;
   }
 
-  const userId = (req.user as any).id;
+  const userId = (req.user as any)._id;
 
   try {
     const list = await RecipeList.findOneAndDelete({ _id: id, user: userId });

--- a/backend/api/routes/auth.ts
+++ b/backend/api/routes/auth.ts
@@ -6,7 +6,7 @@ import jwt, { JwtPayload } from 'jsonwebtoken';
 import env from '../config/env';
 import { authenticate } from '../middleware/auth';
 
-console.log('Auth routes file loaded');
+console.log('Auth routes loading, deleteAccount function:', typeof deleteAccount);
 
 interface UserPayload extends JwtPayload {
   id: string;
@@ -31,6 +31,9 @@ router.get('/test', (req, res) => {
   console.log('Auth test route accessed');
   res.json({ message: 'Auth test route works' });
 });
+router.get('/auth-test', (req, res) => {
+  res.json({ message: 'Authenticated route works' });
+});
 // Google OAuth login route
 router.get(
   '/google',
@@ -52,7 +55,7 @@ router.get(
       // Generate JWT token using the JWT_SECRET
       const token = jwt.sign(
         {
-          id: req.user._id,
+          _id: req.user._id,
           displayName: req.user.displayName,
           email: req.user.email,
           // Use optional chaining for nested properties that might not exist


### PR DESCRIPTION
This pull request includes changes to improve user ID handling across multiple controllers, enhance logging for debugging, and add a new test route in the `auth.ts` file. The most important changes involve consistently using `_id` for user identification and introducing additional logging to aid in debugging.

### User ID Handling Updates:
* [`backend/api/controllers/authControllers.ts`](diffhunk://#diff-82812bba683f8aa6ca0af5a2b0d50a74919ee41ff207a75c3cfe3ae6a1a9da5bL53-R55): Updated the `deleteAccount` function to use `_id` for user identification, with a fallback to `id`, and added debugging logs to display the user object and ID being deleted.
* [`backend/api/controllers/recipeListControllers.ts`](diffhunk://#diff-168a5ae9fb0240d86be633b3d3fc994c8ed93f81af8129980dfb422aa72449a6L13-R13): Standardized user ID handling across multiple functions (`createRecipeList`, `getRecipeLists`, `updateRecipeList`, `deleteRecipeList`) by replacing `id` with `_id`. [[1]](diffhunk://#diff-168a5ae9fb0240d86be633b3d3fc994c8ed93f81af8129980dfb422aa72449a6L13-R13) [[2]](diffhunk://#diff-168a5ae9fb0240d86be633b3d3fc994c8ed93f81af8129980dfb422aa72449a6L32-R32) [[3]](diffhunk://#diff-168a5ae9fb0240d86be633b3d3fc994c8ed93f81af8129980dfb422aa72449a6L53-R53) [[4]](diffhunk://#diff-168a5ae9fb0240d86be633b3d3fc994c8ed93f81af8129980dfb422aa72449a6L86-R86)

### Debugging Enhancements:
* [`backend/api/routes/auth.ts`](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8L9-R9): Replaced an existing log statement with one that logs the type of the `deleteAccount` function for debugging purposes.

### New Test Route:
* [`backend/api/routes/auth.ts`](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8R34-R36): Added a new `/auth-test` route to verify authentication functionality, returning a simple JSON response.

### Minor Adjustment:
* [`backend/api/routes/auth.ts`](diffhunk://#diff-3fa07659353107e4164e25b4e77601f8c5ad59b0bc9ee3c48a4684edbc501fe8L55-R58): Updated the JWT payload to use `_id` instead of `id` for consistency.