### PR TITLE
Pages

### DIFF
--- a/frontend/hajkmat-frontend/src/App.tsx
+++ b/frontend/hajkmat-frontend/src/App.tsx
@@ -5,6 +5,7 @@ import TitleUpdater from './components/TitleUpdater';
 import Home from './components/Main/Home/Home';
 import Login from './components/auth/Login';
 import ProfilePage from './components/Main/ProfilePage';
+import AboutUs from './components/Main/AboutUs';
 import { ProtectedRoute } from './components/auth/ProtectedRoute';
 import { AuthProvider } from './hooks/useAuth';
 import AuthCallback from './components/auth/AuthCallback';
@@ -21,6 +22,7 @@ function App() {
             {/* Your page content goes here */}
             <Routes>
               <Route path="/" element={<Home />} /> {/* Home is now accessible to everyone */}
+              <Route path="about" element={<AboutUs />} />
               <Route path="/login" element={<Login />} /> {/* New login route */}
               <Route path="/auth-callback" element={<AuthCallback />} />
               {/* Protected routes */}

--- a/frontend/hajkmat-frontend/src/components/Main/AboutUs.tsx
+++ b/frontend/hajkmat-frontend/src/components/Main/AboutUs.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+const AboutUs: React.FC = () => {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Om Hajkmat</h1>
+
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-4">Mitt uppdrag</h2>
+        <p className="mb-4">
+          Välkommen till Hajkmat - din ultimata följeslagare för måltidsplanering och matlagning på
+          äventyr! Jag startade Hajkmat med en enkel vision: att göra utomhusmatlagning enklare,
+          roligare och mer tillgänglig för alla äventyrare och naturälskare.
+        </p>
+        <p>
+          Oavsett om du planerar en dagsutflykt, en långhelg i vildmarken eller en längre vandring,
+          hjälper Hajkmat dig att planera, organisera och förbereda dina måltider så att du kan
+          fokusera på det viktigaste att njuta av naturen.
+        </p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-2xl font-semibold mb-4">Vad Hajkmat erbjuder</h2>
+        <div className="grid md:grid-cols-2 gap-6">
+          <div>
+            <h3 className="text-xl font-medium mb-2">Receptsamlingar</h3>
+            <p>
+              Utforska hundratals recept speciellt anpassade för utomhusmatlagning. Varje recept är
+              testat i fält och optimerat för enkla ingredienser och minimal utrustning.
+            </p>
+          </div>
+          <div>
+            <h3 className="text-xl font-medium mb-2">Personliga listor</h3>
+            <p>
+              Skapa dina egna receptlistor och anpassa dem efter dina preferenser, kostrestriktioner
+              och typen av äventyr du planerar.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default AboutUs;

--- a/frontend/hajkmat-frontend/src/components/Main/ProfilePage.tsx
+++ b/frontend/hajkmat-frontend/src/components/Main/ProfilePage.tsx
@@ -19,29 +19,27 @@ const ProfilePage = () => {
     try {
       const token = localStorage.getItem('auth_token');
 
-      console.log('Trying primary delete route...');
-      let response = await fetch(`${API_URL}/auth/delete-account`, {
+      console.log('Attempting to delete account...');
+      const response = await fetch(`${API_URL}/auth/delete-account`, {
         method: 'DELETE',
-        headers: { Authorization: `Bearer ${token}` },
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       });
 
-      // Use Record<string, any> for a simple type assertion
-      const data = (await response.json()) as Record<string, any>;
-
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to delete account');
+        throw new Error('Failed to delete account');
       }
 
-      // Now TypeScript won't complain about accessing properties
-      console.log('Account deleted successfully:', data.message);
-
+      // Use the logout function from your auth context
+      // This will handle removing the token and updating state
       await logout();
+
+      // Navigate to home page
       navigate('/', { replace: true });
     } catch (err) {
       console.error('Delete account error:', err);
-      setError(
-        typeof err === 'object' && err instanceof Error ? err.message : 'Failed to delete account',
-      );
+      setError('Failed to delete account');
     }
   };
 

--- a/frontend/hajkmat-frontend/src/hooks/useAuth.ts
+++ b/frontend/hajkmat-frontend/src/hooks/useAuth.ts
@@ -100,6 +100,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
       // Remove token instead of clearing cookies
       localStorage.removeItem('auth_token');
 
+      // Update authentication state in your app
+      setIsAuthenticated(false);
+      setUser(null);
+
       return true;
     } catch (err) {
       console.error('Logout failed:', err);


### PR DESCRIPTION
This pull request introduces a new `AboutUs` page to the Hajkmat application, refines the account deletion logic, and improves the authentication state management. Below are the most important changes grouped by theme.

### New `AboutUs` Page:

* [`frontend/hajkmat-frontend/src/App.tsx`](diffhunk://#diff-74ab0759cfb30c865d0751a270354ae1360b84710d8f61b59db963f5b4239210R8): Added a new route `/about` for the `AboutUs` page and imported the corresponding component. [[1]](diffhunk://#diff-74ab0759cfb30c865d0751a270354ae1360b84710d8f61b59db963f5b4239210R8) [[2]](diffhunk://#diff-74ab0759cfb30c865d0751a270354ae1360b84710d8f61b59db963f5b4239210R25)
* [`frontend/hajkmat-frontend/src/components/Main/AboutUs.tsx`](diffhunk://#diff-50af340b8d0c6067f4bd259799b1e4d84e93cb964b949b3e89ec6673aa933c01R1-R45): Implemented the new `AboutUs` page, which includes sections describing Hajkmat's mission and offerings like recipe collections and personalized lists.

### Account Deletion Refinements:

* [`frontend/hajkmat-frontend/src/components/Main/ProfilePage.tsx`](diffhunk://#diff-d2d7b04bd1d5d1ed1a7aa572e4a73ef21d0d8b506c988db1e59050b0cb62e443L22-R42): Simplified error handling and removed unnecessary type assertions in the account deletion logic. Added a logout call and navigation to the home page after account deletion.

### Authentication State Improvements:

* [`frontend/hajkmat-frontend/src/hooks/useAuth.ts`](diffhunk://#diff-0ed49421a7ca6e925cad9c21c62903a312a8eb896ebf425bc8c0e0eb07f41344R103-R106): Enhanced the logout function to update authentication state by setting `isAuthenticated` to `false` and clearing the `user` object.