### PR TITLE
Fix: recepielist

### DIFF
--- a/backend/api/controllers/recipeListControllers.ts
+++ b/backend/api/controllers/recipeListControllers.ts
@@ -1,3 +1,26 @@
+// Get a single recipe list by ID (with recipes populated)
+export const getRecipeListById = async (req: Request, res: Response): Promise<void> => {
+  const { id } = req.params;
+
+  if (!req.user) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+
+  const userId = req.user._id || req.user.id;
+
+  try {
+    const list = await RecipeList.findOne({ _id: id, userId: userId }).populate('recipes');
+    if (!list) {
+      res.status(404).json({ error: 'Recipe list not found' });
+      return;
+    }
+    res.status(200).json({ list });
+  } catch (error) {
+    console.error('Failed to retrieve recipe list:', error);
+    res.status(500).json({ error: 'Failed to retrieve recipe list' });
+  }
+};
 import { Request, Response } from 'express';
 import { Types } from 'mongoose';
 import RecipeList from '../models/recipeList';

--- a/backend/api/routes/recipeLists.ts
+++ b/backend/api/routes/recipeLists.ts
@@ -6,6 +6,7 @@ import {
   deleteRecipeList,
   addRecipeToList,
   removeRecipeFromList,
+  getRecipeListById,
 } from '../controllers/recipeListControllers';
 import { authenticate } from '../middleware/auth';
 
@@ -16,6 +17,9 @@ router.post('/', authenticate, createRecipeList);
 
 // Get all recipe lists for the authenticated user
 router.get('/', authenticate, getRecipeLists);
+
+// Get a single recipe list by ID (with recipes populated)
+router.get('/:id', authenticate, getRecipeListById);
 
 // Update recipe list
 router.put('/:id', authenticate, updateRecipeList);


### PR DESCRIPTION
This pull request introduces a new feature to retrieve a single recipe list by its ID, with its associated recipes populated. It includes changes to the controller, routes, and middleware setup to support this functionality.

### New feature: Retrieve a single recipe list by ID

#### Controller updates:
* Added a new `getRecipeListById` function in `backend/api/controllers/recipeListControllers.ts` to handle fetching a recipe list by ID for authenticated users. This includes error handling for unauthorized access, missing recipe lists, and server errors.

#### Route updates:
* Imported the new `getRecipeListById` function in `backend/api/routes/recipeLists.ts`.
* Added a new route `GET /:id` to fetch a specific recipe list by ID, ensuring it uses the `authenticate` middleware for user authentication.